### PR TITLE
Include job id in notifications stream

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,10 @@ lazy val core = project
   .settings(name := "fs2-job")
   .settings(
     libraryDependencies ++= Seq(
-        "co.fs2" %% "fs2-core" % "1.0.4",
-        "org.specs2" %% "specs2-core" % "4.3.4" % "test"),
+        "co.fs2" %% "fs2-core" % "1.0.5",
+        "org.specs2" %% "specs2-core" % "4.6.0" % "test"),
 
-    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"),
+    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"),
     performMavenCentralSync := false,
     publishAsOSSProject := true)
   .enablePlugins(AutomateHeaderPlugin)

--- a/core/src/main/scala/fs2/job/Event.scala
+++ b/core/src/main/scala/fs2/job/Event.scala
@@ -16,16 +16,16 @@
 
 package fs2.job
 
-import scala.{Product, Serializable}
+import scala.{Product, Serializable, Option}
 
 import java.lang.Throwable
-import java.time.OffsetDateTime
+import java.time.Instant
 
 import scala.concurrent.duration.Duration
 
 sealed trait Event[I] extends Product with Serializable
 
 object Event {
-  final case class Completed[I](id: I, timestamp: OffsetDateTime) extends Event[I]
-  final case class Failed[I](id: I, timestamp: OffsetDateTime, ex: Throwable) extends Event[I]
+  final case class Completed[I](id: I, startingTime: Instant, duration: Duration) extends Event[I]
+  final case class Failed[I](id: I, startingTime: Instant, ex: Throwable, duration: Duration) extends Event[I]
 }

--- a/core/src/main/scala/fs2/job/Event.scala
+++ b/core/src/main/scala/fs2/job/Event.scala
@@ -20,11 +20,11 @@ import scala.{Product, Serializable}
 import scala.concurrent.duration.Duration
 
 import java.lang.Throwable
-import java.time.Instant
+import java.time.OffsetDateTime
 
 sealed trait Event[I] extends Product with Serializable
 
 object Event {
-  final case class Completed[I](id: I, startingTime: Instant, duration: Duration) extends Event[I]
-  final case class Failed[I](id: I, startingTime: Instant, ex: Throwable, duration: Duration) extends Event[I]
+  final case class Completed[I](id: I, startingTime: OffsetDateTime, duration: Duration) extends Event[I]
+  final case class Failed[I](id: I, startingTime: OffsetDateTime, ex: Throwable, duration: Duration) extends Event[I]
 }

--- a/core/src/main/scala/fs2/job/Event.scala
+++ b/core/src/main/scala/fs2/job/Event.scala
@@ -16,7 +16,7 @@
 
 package fs2.job
 
-import scala.{Product, Serializable, Option}
+import scala.{Product, Serializable}
 
 import java.lang.Throwable
 import java.time.Instant

--- a/core/src/main/scala/fs2/job/Event.scala
+++ b/core/src/main/scala/fs2/job/Event.scala
@@ -23,18 +23,9 @@ import java.time.OffsetDateTime
 
 import scala.concurrent.duration.Duration
 
-import cats.Eq
-
 sealed trait Event[I] extends Product with Serializable
 
 object Event {
   final case class Completed[I](id: I, timestamp: OffsetDateTime) extends Event[I]
   final case class Failed[I](id: I, timestamp: OffsetDateTime, ex: Throwable) extends Event[I]
-  final case class Canceled[I](id: I, timestamp: OffsetDateTime) extends Event[I]
-
-  implicit def equal[I: Eq]: Eq[Event[I]] = Eq.instance[Event[I]]  {
-    case (Completed(id1, _), Completed(id2, _)) => Eq[I].eqv(id1, id2)
-    case (Failed(id1, _, _), Failed(id2, _, _)) => Eq[I].eqv(id1, id2)
-    case _ => false
-  }
 }

--- a/core/src/main/scala/fs2/job/Event.scala
+++ b/core/src/main/scala/fs2/job/Event.scala
@@ -17,11 +17,10 @@
 package fs2.job
 
 import scala.{Product, Serializable}
+import scala.concurrent.duration.Duration
 
 import java.lang.Throwable
 import java.time.Instant
-
-import scala.concurrent.duration.Duration
 
 sealed trait Event[I] extends Product with Serializable
 

--- a/core/src/main/scala/fs2/job/Event.scala
+++ b/core/src/main/scala/fs2/job/Event.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.job
+
+import scala.{Product, Serializable}
+
+import java.lang.Throwable
+import java.time.OffsetDateTime
+
+import scala.concurrent.duration.Duration
+
+import cats.Eq
+
+sealed trait Event[I] extends Product with Serializable
+
+object Event {
+  final case class Completed[I](id: I, timestamp: OffsetDateTime) extends Event[I]
+  final case class Failed[I](id: I, timestamp: OffsetDateTime, ex: Throwable) extends Event[I]
+  final case class Canceled[I](id: I, timestamp: OffsetDateTime) extends Event[I]
+
+  implicit def equal[I: Eq]: Eq[Event[I]] = Eq.instance[Event[I]]  {
+    case (Completed(id1, _), Completed(id2, _)) => Eq[I].eqv(id1, id2)
+    case (Failed(id1, _, _), Failed(id2, _, _)) => Eq[I].eqv(id1, id2)
+    case _ => false
+  }
+}

--- a/core/src/main/scala/fs2/job/JobManager.scala
+++ b/core/src/main/scala/fs2/job/JobManager.scala
@@ -20,7 +20,7 @@ package job
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
-import cats.effect.{Concurrent, ExitCase, Timer}
+import cats.effect.{Concurrent, Timer}
 
 import fs2.concurrent.{Queue, SignallingRef}
 

--- a/core/src/main/scala/fs2/job/JobManager.scala
+++ b/core/src/main/scala/fs2/job/JobManager.scala
@@ -17,8 +17,6 @@
 package fs2
 package job
 
-import cats.Eq
-import cats.syntax.eq._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
@@ -42,7 +40,7 @@ import java.util.concurrent.ConcurrentHashMap
  * from jobs, deterministic cancelation, "fire and forget"
  * submission, and sidecar-style cancelation of direct streams.
  */
-final class JobManager[F[_]: Concurrent: Timer, I: Eq, N] private (
+final class JobManager[F[_]: Concurrent: Timer, I, N] private (
     notificationsQ: Queue[F, Option[(I, N)]],
     eventQ: Queue[F, Option[Event[I]]],
     dispatchQ: Queue[F, Stream[F, Nothing]]) {
@@ -218,7 +216,7 @@ final class JobManager[F[_]: Concurrent: Timer, I: Eq, N] private (
 object JobManager {
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-  def apply[F[_]: Concurrent: Timer, I: Eq, N](
+  def apply[F[_]: Concurrent: Timer, I, N](
       jobLimit: Int = 100,
       notificationsLimit: Int = 10,
       eventsLimit: Int = 10)   // all numbers are arbitrary, really

--- a/core/src/main/scala/fs2/job/JobManager.scala
+++ b/core/src/main/scala/fs2/job/JobManager.scala
@@ -114,14 +114,6 @@ final class JobManager[F[_]: Concurrent: Timer, I: Eq, N] private (
   def jobIds: F[List[I]] =
     Concurrent[F].delay(meta.keys.asScala.toList)
 
-   /**
-    * Returns the notifications associated with the given job id
-    */
-   def notificationsOf(id: I): Stream[F, N] =
-     notificationsQ.dequeue.unNone.filter {
-       case (i, n) => i === id
-     }.map(_._2)
-
   /**
    * Cancels the job by id. If the job does not exist, this call
    * will be ignored.

--- a/core/src/test/scala/fs2/job/JobManagerSpec.scala
+++ b/core/src/test/scala/fs2/job/JobManagerSpec.scala
@@ -30,6 +30,7 @@ import java.time.temporal.ChronoUnit
 
 import cats.Eq
 import cats.effect.IO
+import cats.instances.int._
 import cats.instances.string._
 import fs2.concurrent.SignallingRef
 import org.specs2.mutable._
@@ -136,7 +137,7 @@ object JobManagerSpec extends Specification {
         _ <- await
 
         // folds keeps pulling and blocks, even after the stream is done emitting
-        ns <- mgr.notifications.take(2).fold(List[String]()) {
+        ns <- mgr.notificationsOf(JobId).take(2).fold(List[String]()) {
           case (acc, elem) => acc :+ elem
         }
       } yield ns).compile.lastOrError.timeout(Timeout).unsafeRunSync

--- a/core/src/test/scala/fs2/job/JobManagerSpec.scala
+++ b/core/src/test/scala/fs2/job/JobManagerSpec.scala
@@ -24,8 +24,8 @@ import scala.concurrent.duration._
 import scala.util.{Either, Left, Right}
 import scala.{Int, List, Unit}
 
-import java.time.Instant
 import java.lang.Exception
+import java.time.Instant
 
 import cats.Eq
 import cats.effect.IO

--- a/core/src/test/scala/fs2/job/JobManagerSpec.scala
+++ b/core/src/test/scala/fs2/job/JobManagerSpec.scala
@@ -30,7 +30,6 @@ import java.time.temporal.ChronoUnit
 
 import cats.Eq
 import cats.effect.IO
-import cats.instances.int._
 import cats.instances.string._
 import fs2.concurrent.SignallingRef
 import org.specs2.mutable._
@@ -137,7 +136,7 @@ object JobManagerSpec extends Specification {
         _ <- await
 
         // folds keeps pulling and blocks, even after the stream is done emitting
-        ns <- mgr.notificationsOf(JobId).take(2).fold(List[String]()) {
+        ns <- mgr.notifications.map(_._2).take(2).fold(List[String]()) {
           case (acc, elem) => acc :+ elem
         }
       } yield ns).compile.lastOrError.timeout(Timeout).unsafeRunSync

--- a/core/src/test/scala/fs2/job/JobManagerSpec.scala
+++ b/core/src/test/scala/fs2/job/JobManagerSpec.scala
@@ -38,7 +38,7 @@ object JobManagerSpec extends Specification {
   implicit val timer = IO.timer(ExecutionContext.global)
 
   // how long we sleep to simulate work in streams
-  val WorkingTime = 100.milliseconds
+  val WorkingTime = 500.milliseconds
 
   // how long we wait for EACH test to finish. This is important since latchGet may block indefinitely.
   val Timeout = WorkingTime * 10


### PR DESCRIPTION
Depends on #4. 🛑 up and unassigned because of that.

This also makes the event and notification queues into circular buffers. This was done because `submit` and `tap` will block unless events and notifications are consumed by the user, which might be undesirable if the user isn't interested in the notifications.