### PR TITLE
 Allow JobManager users to indicate which notifications should apply backpressure

### DIFF
--- a/core/src/main/scala/fs2/job/Event.scala
+++ b/core/src/main/scala/fs2/job/Event.scala
@@ -17,13 +17,15 @@
 package fs2.job
 
 import scala.{Product, Serializable}
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 
 import java.lang.Throwable
 
 sealed trait Event[I] extends Product with Serializable
 
 object Event {
-  final case class Completed[I](id: I, start: Duration, duration: Duration) extends Event[I]
-  final case class Failed[I](id: I, start: Duration, duration: Duration, ex: Throwable) extends Event[I]
+  final case class Completed[I](id: I, start: Timestamp, duration: FiniteDuration) extends Event[I]
+  final case class Failed[I](id: I, start: Timestamp, duration: FiniteDuration, ex: Throwable) extends Event[I]
 }
+
+final case class Timestamp(val epoch: FiniteDuration)

--- a/core/src/main/scala/fs2/job/JobManager.scala
+++ b/core/src/main/scala/fs2/job/JobManager.scala
@@ -33,8 +33,7 @@ import scala.util.{Left, Right}
 import scala.{Array, Boolean, Int, List, Option, None, Nothing, Some, Unit}
 
 import java.lang.{RuntimeException, SuppressWarnings}
-import java.time.Instant
-import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap}
 
 /**
  * A coordination mechanism for parallel job management. This
@@ -239,9 +238,8 @@ final class JobManager[F[_]: Concurrent: Timer, I, N] private (
   }
 
   private def epochMillisNow: F[Timestamp] =
-    Concurrent[F]
-      .delay(Instant.now().toEpochMilli)
-      .map(FiniteDuration(_, TimeUnit.MILLISECONDS))
+    Timer[F].clock.realTime(MILLISECONDS)
+      .map(FiniteDuration(_, MILLISECONDS))
       .map(Timestamp(_))
 }
 

--- a/core/src/main/scala/fs2/job/JobManager.scala
+++ b/core/src/main/scala/fs2/job/JobManager.scala
@@ -21,7 +21,6 @@ import cats.effect.{Concurrent, Timer}
 import cats.instances.list._
 import cats.instances.option._
 import cats.syntax.alternative._
-import cats.syntax.eq._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
@@ -69,10 +68,7 @@ final class JobManager[F[_]: Concurrent: Timer, I, N] private (
       .unNone
       .tupleLeft(job.id)
       .evalMap({
-        case (i, n) if job.reportOn(n) === Report.Emit =>
-          notificationsQ.enqueue1(Some((i, n)))
-        case (i, n) =>
-          Concurrent[F].unit
+        case (i, n) => notificationsQ.enqueue1(Some((i, n)))
       }).drain
 
     val putStatusF = Concurrent[F] delay {

--- a/core/src/test/scala/fs2/job/JobManagerSpec.scala
+++ b/core/src/test/scala/fs2/job/JobManagerSpec.scala
@@ -38,8 +38,11 @@ object JobManagerSpec extends Specification {
   implicit val cs = IO.contextShift(ExecutionContext.global)
   implicit val timer = IO.timer(ExecutionContext.global)
 
+  // two durations are considered equal if they're within Delta of each other
+  val Delta = 50.milliseconds
+
   // how long we sleep to simulate work in streams
-  val WorkingTime = 500.milliseconds
+  val WorkingTime = Delta * 10
 
   // how long we wait for EACH test to finish. This is important since latchGet may block indefinitely.
   val Timeout = WorkingTime * 10
@@ -289,7 +292,7 @@ object JobManagerSpec extends Specification {
         event must beLike {
           case Event.Failed(id, _, duration, ex) =>
             ex.getMessage mustEqual "boom"
-            duration.toMillis must beCloseTo(endTime - startTime, 1.significantFigures)
+            duration.toMillis must beCloseTo(endTime - startTime, Delta)
             id mustEqual JobId
         }
       }
@@ -313,7 +316,7 @@ object JobManagerSpec extends Specification {
       } yield {
         event must beLike {
           case Event.Completed(id, _, duration) =>
-            duration.toMillis must beCloseTo(endTime - startTime, 1.significantFigures)
+            duration.toMillis must beCloseTo(endTime - startTime, Delta)
             id mustEqual JobId
         }
       }

--- a/core/src/test/scala/fs2/job/JobManagerSpec.scala
+++ b/core/src/test/scala/fs2/job/JobManagerSpec.scala
@@ -39,10 +39,10 @@ object JobManagerSpec extends Specification {
   implicit val timer = IO.timer(ExecutionContext.global)
 
   // two durations are considered equal if they're within Delta of each other
-  val Delta = 50.milliseconds
+  val Delta = 50L
 
   // how long we sleep to simulate work in streams
-  val WorkingTime = Delta * 10
+  val WorkingTime = (Delta * 10).milliseconds
 
   // how long we wait for EACH test to finish. This is important since latchGet may block indefinitely.
   val Timeout = WorkingTime * 10


### PR DESCRIPTION
[ch8167]

🛑 up because this depends on #4.

Changes specific to this PR [begin here](https://github.com/slamdata/fs2-job/pull/6/commits/b66d8fc5f697040e8ad587195d4e1577b21840ef).

[More details on the design can be found in Clubhouse](https://app.clubhouse.io/data/story/8167).