### PR TITLE
A trio of bug fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val core = project
   .settings(name := "fs2-job")
   .settings(
     libraryDependencies ++= Seq(
-        "co.fs2" %% "fs2-core" % "2.4.4",
+        "co.fs2" %% "fs2-core" % "2.4.5",
         "org.specs2" %% "specs2-core" % "4.10.5" % "test"),
 
     addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),

--- a/core/src/main/scala/fs2/job/JobManager.scala
+++ b/core/src/main/scala/fs2/job/JobManager.scala
@@ -24,9 +24,9 @@ import fs2.concurrent.{Queue, SignallingRef}
 
 import scala.concurrent.duration._
 import scala.util.{Left, Right}
-import scala.{Array, Boolean, Int, List, Option, None, Nothing, Some, StringContext, Unit}
+import scala.{Boolean, Int, List, Option, None, Nothing, Some, StringContext, Unit}
 
-import java.lang.{IllegalStateException, SuppressWarnings}
+import java.lang.IllegalStateException
 import java.util.concurrent.{ConcurrentHashMap}
 
 /**
@@ -57,7 +57,6 @@ final class JobManager[F[_]: Concurrent: Timer, I, N] private (
    * Attempting to submit a job with the same id as a pre-existing job will
    * produce false.
    */
-  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments", "org.wartremover.warts.Equals"))
   def submit[R](job: Job[F, I, N, R]): F[Boolean] = {
     val run = job.run
       .map(_.swap.toOption)
@@ -125,7 +124,6 @@ final class JobManager[F[_]: Concurrent: Timer, I, N] private (
    * Cancels the job by id. If the job does not exist, this call
    * will be ignored.
    */
-  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
   def cancel(id: I): F[Unit] = {
     Concurrent[F].delay(meta.get(id)) flatMap {
       case Context(Status.Running, Some(cancelF)) =>
@@ -244,8 +242,6 @@ final class JobManager[F[_]: Concurrent: Timer, I, N] private (
 }
 
 object JobManager {
-
-  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
   def apply[F[_]: Concurrent: Timer, I, N](
       jobLimit: Int = 100,
       notificationsLimit: Int = 10,

--- a/core/src/test/scala/fs2/job/JobManagerSpec.scala
+++ b/core/src/test/scala/fs2/job/JobManagerSpec.scala
@@ -374,7 +374,8 @@ class JobManagerSpec extends Specification {
           event must beLike {
             case Event.Failed(id, _, duration, ex) =>
               ex.getMessage mustEqual "boom"
-              duration.toMillis must beCloseTo(endTime - startTime, Delta)
+              duration.toMillis must be_>=(WorkingTime.toMillis)
+              duration.toMillis must be_<(2 * WorkingTime.toMillis)
               id mustEqual JobId
           }
         }
@@ -399,7 +400,8 @@ class JobManagerSpec extends Specification {
         } yield {
           event must beLike {
             case Event.Completed(id, _, duration) =>
-              duration.toMillis must beCloseTo(endTime - startTime, Delta)
+              duration.toMillis must be_>=(WorkingTime.toMillis)
+              duration.toMillis must be_<(2 * WorkingTime.toMillis)
               id mustEqual JobId
           }
         }

--- a/core/src/test/scala/fs2/job/JobManagerSpec.scala
+++ b/core/src/test/scala/fs2/job/JobManagerSpec.scala
@@ -137,7 +137,7 @@ class JobManagerSpec extends Specification {
           statusAfterCancel <- mgr.status(JobId)
           refAfterCancel <- ref.get
         } yield {
-          statusBeforeCancel must beSome(Status.Running)
+          statusBeforeCancel must beSome(Status.Running: Status)
           refBeforeCancel mustEqual "Started"
           statusAfterCancel must beNone
           refAfterCancel mustEqual "Working"
@@ -181,8 +181,8 @@ class JobManagerSpec extends Specification {
           submit1 must beTrue
           submit2 must beTrue
           ids must_== List(JobId1, JobId2)
-          status1 must beSome(Status.Running)
-          status2 must beSome(Status.Pending)
+          status1 must beSome(Status.Running: Status)
+          status2 must beSome(Status.Pending: Status)
 
           r must beLeft.like {
             case t: TimeoutException => true


### PR DESCRIPTION
Fixes the following issues

1. Submitted jobs canceled while pending were still run
2. Status of a job did not reflect termination when termination events emitted (i.e. the `JobManager` still considered a job to be "running" when sending complete/failed events)
3. Events were emitted with the "end" timestamp rather than the "start" timestamp.

[ch12129]
[ch12131]