### PR TITLE
Make cancellation of a pending job immediate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.12, 2.13.1]
+        scala: [2.12.12, 2.13.3]
         java: [adopt@1.8, graalvm8@20.1.0]
     runs-on: ${{ matrix.os }}
     steps:
@@ -116,12 +116,12 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13.1)
+      - name: Download target directories (2.13.3)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-2.13.1-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.13.3-${{ matrix.java }}
 
-      - name: Inflate target directories (2.13.1)
+      - name: Inflate target directories (2.13.3)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import scala.Some
 import scala.collection.Seq
 
-ThisBuild / crossScalaVersions := Seq("2.12.12", "2.13.1")
+ThisBuild / crossScalaVersions := Seq("2.12.12", "2.13.3")
 ThisBuild / scalaVersion := "2.12.12"
 
 ThisBuild / githubRepository := "fs2-job"
@@ -27,7 +27,7 @@ lazy val core = project
   .settings(name := "fs2-job")
   .settings(
     libraryDependencies ++= Seq(
-        "co.fs2" %% "fs2-core" % "2.4.5",
+        "co.fs2" %% "fs2-core" % "2.4.6",
         "org.specs2" %% "specs2-core" % "4.10.5" % "test"),
 
     addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),

--- a/core/src/main/scala/fs2/job/Event.scala
+++ b/core/src/main/scala/fs2/job/Event.scala
@@ -28,8 +28,21 @@ sealed trait Event[I] extends Product with Serializable {
 }
 
 object Event {
-  final case class Completed[I](id: I, start: Timestamp, duration: FiniteDuration) extends Event[I]
-  final case class Failed[I](id: I, start: Timestamp, duration: FiniteDuration, ex: Throwable) extends Event[I]
+  final case class Completed[I](
+      id: I,
+      start: Timestamp,
+      duration: FiniteDuration) extends Event[I]
+
+  final case class Failed[I](
+      id: I,
+      start: Timestamp,
+      duration: FiniteDuration,
+      ex: Throwable) extends Event[I]
+
+  final case class Canceled[I](
+      id: I,
+      start: Timestamp,
+      duration: FiniteDuration) extends Event[I]
 }
 
 final case class Timestamp(epoch: FiniteDuration)

--- a/core/src/main/scala/fs2/job/Event.scala
+++ b/core/src/main/scala/fs2/job/Event.scala
@@ -21,9 +21,17 @@ import scala.concurrent.duration.FiniteDuration
 
 import java.lang.Throwable
 
+/**
+ * Managed job termination event.
+ */
 sealed trait Event[I] extends Product with Serializable {
+  /** Job identifier. */
   def id: I
+
+  /** When the job started (as opposed to submitted). */
   def start: Timestamp
+
+  /** Duration the job ran before terminating. */
   def duration: FiniteDuration
 }
 

--- a/core/src/main/scala/fs2/job/Event.scala
+++ b/core/src/main/scala/fs2/job/Event.scala
@@ -21,11 +21,15 @@ import scala.concurrent.duration.FiniteDuration
 
 import java.lang.Throwable
 
-sealed trait Event[I] extends Product with Serializable
+sealed trait Event[I] extends Product with Serializable {
+  def id: I
+  def start: Timestamp
+  def duration: FiniteDuration
+}
 
 object Event {
   final case class Completed[I](id: I, start: Timestamp, duration: FiniteDuration) extends Event[I]
   final case class Failed[I](id: I, start: Timestamp, duration: FiniteDuration, ex: Throwable) extends Event[I]
 }
 
-final case class Timestamp(val epoch: FiniteDuration)
+final case class Timestamp(epoch: FiniteDuration)

--- a/core/src/main/scala/fs2/job/JobManager.scala
+++ b/core/src/main/scala/fs2/job/JobManager.scala
@@ -191,12 +191,12 @@ final class JobManager[F[_]: Concurrent: Timer, I, N] private (
             case Some(old @ Context(Status.Pending, cancel)) =>
               val running = Context(Status.Running, cancel)
 
-              val casF = Concurrent[F] delay {
+              val replacedF = Concurrent[F] delay {
                 meta.replace(id, old, running)
               }
 
-              casF flatMap { result =>
-                if (result)
+              replacedF flatMap { replaced =>
+                if (replaced)
                   Concurrent[F].pure(Some(running))
                 else
                   attemptF
@@ -209,12 +209,12 @@ final class JobManager[F[_]: Concurrent: Timer, I, N] private (
             case None if ignoreAbsence =>
               val running = Context(Status.Running, isCanceled.set(true))
 
-              val casF = Concurrent[F] delay {
+              val putF = Concurrent[F] delay {
                 Option(meta.putIfAbsent(id, running)).isEmpty
               }
 
-              casF flatMap { result =>
-                if (result)
+              putF flatMap { put =>
+                if (put)
                   Concurrent[F].pure(Some(running))
                 else
                   attemptF

--- a/core/src/main/scala/fs2/job/Status.scala
+++ b/core/src/main/scala/fs2/job/Status.scala
@@ -19,16 +19,12 @@ package fs2.job
 import cats.Eq
 
 import scala.{Product, Serializable}
-// import scala.concurrent.duration.FiniteDuration
 
 sealed trait Status extends Product with Serializable
 
 object Status {
-  implicit val equal: Eq[Status] = Eq.fromUniversalEquals[Status]
-
   case object Pending extends Status
-  case object Canceled extends Status   // kill marker to prevent already-scheduled task
-
-  // final case class Scheduled(fromNow: FiniteDuration) extends Status
   case object Running extends Status
+
+  implicit val equal: Eq[Status] = Eq.fromUniversalEquals[Status]
 }

--- a/core/src/test/scala/fs2/job/JobManagerSpec.scala
+++ b/core/src/test/scala/fs2/job/JobManagerSpec.scala
@@ -51,7 +51,7 @@ class JobManagerSpec extends Specification {
 
   implicit class RunExample(s: String) {
     def >>*[A: AsResult](io: => IO[A]): Fragment =
-      s >> io.timeout(Timeout).unsafeRunSync
+      s >> io.timeout(Timeout).unsafeRunSync()
   }
 
   def await: Stream[IO, Unit] =


### PR DESCRIPTION
Removes the `Canceled` state used as a marker to indicate a pending job was canceled in favor of making cancelation of such a job take effect immediately. Also adds `JobEvent.Canceled` to be able to observe cancelation downstream and adjusts when event `start` is recorded so it reflects when the job actually ran instead of when it was submitted.

[ch12651]